### PR TITLE
Fix scene and buttons

### DIFF
--- a/src/Vis/Emitters.jl
+++ b/src/Vis/Emitters.jl
@@ -24,7 +24,7 @@ const MARKER_SIZE = 1
 #-------------------------------------
 # draw debug information - local axes and positions
 #-------------------------------------
-function maybe_draw_debug_info(scene::Makie.LScene, o::Origins.AbstractOriginDistribution; transform::Geometry.Transform = Transform(), debug::Bool=false, kwargs...) where {T<:Real}
+function maybe_draw_debug_info(ax::Makie.AbstractAxis, o::Origins.AbstractOriginDistribution; transform::Geometry.Transform = Transform(), debug::Bool=false, kwargs...) where {T<:Real}
 
     dir = forward(transform)
     uv = SVector{3}(right(transform))
@@ -32,29 +32,23 @@ function maybe_draw_debug_info(scene::Makie.LScene, o::Origins.AbstractOriginDis
     pos = origin(transform)
 
     if (debug)
-        # this is a stupid hack to force makie to render in 3d - for some scenes, makie decide with no apparent reason to show in 2d instead of 3d
-        Makie.scatter!(scene, [pos[1], pos[1]+0.1], [pos[2], pos[2]+0.1], [pos[3], pos[3]+0.1], color=:red, markersize=0)
-
         # draw the origin and normal of the surface
-        Makie.scatter!(scene, pos, color=:blue, markersize = MARKER_SIZE * visual_size(o))
+        Makie.scatter!(ax, pos, color=:blue, markersize = MARKER_SIZE * visual_size(o))
 
         # normal
         arrow_size = ARRROW_SIZE * visual_size(o)
         arrow_start = pos
         arrow_end = dir * ARRROW_LENGTH * visual_size(o) 
-        Makie.arrows!(scene.scene, [Makie.Point3f(arrow_start)], [Makie.Point3f(arrow_end)], arrowsize=arrow_size, linewidth=arrow_size * 0.5, linecolor=:blue, arrowcolor=:blue)
+        Makie.arrows!(ax, [Makie.Point3f(arrow_start)], [Makie.Point3f(arrow_end)], arrowsize=arrow_size, linewidth=arrow_size * 0.5, linecolor=:blue, arrowcolor=:blue)
         arrow_end = uv * 0.5 * ARRROW_LENGTH * visual_size(o) 
-        Makie.arrows!(scene.scene, [Makie.Point3f(arrow_start)], [Makie.Point3f(arrow_end)], arrowsize= 0.5 * arrow_size, linewidth=arrow_size * 0.5, linecolor=:red, arrowcolor=:red)
+        Makie.arrows!(ax, [Makie.Point3f(arrow_start)], [Makie.Point3f(arrow_end)], arrowsize= 0.5 * arrow_size, linewidth=arrow_size * 0.5, linecolor=:red, arrowcolor=:red)
         arrow_end = vv * 0.5 * ARRROW_LENGTH * visual_size(o) 
-        Makie.arrows!(scene.scene, [Makie.Point3f(arrow_start)], [Makie.Point3f(arrow_end)], arrowsize= 0.5 * arrow_size, linewidth=arrow_size * 0.5, linecolor=:green, arrowcolor=:green)
+        Makie.arrows!(ax, [Makie.Point3f(arrow_start)], [Makie.Point3f(arrow_end)], arrowsize= 0.5 * arrow_size, linewidth=arrow_size * 0.5, linecolor=:green, arrowcolor=:green)
 
         # draw all the samples origins
         positions = map(x -> transform*x, collect(o))
         positions = collect(Makie.Point3f, positions)
-        Makie.scatter!(scene, positions, color=:green, markersize = MARKER_SIZE * visual_size(o))
-
-        # positions = collect(Makie.Point3f, o)
-        # Makie.scatter!(scene, positions, color=:green, markersize = MARKER_SIZE * visual_size(o))
+        Makie.scatter!(ax, positions, color=:green, markersize = MARKER_SIZE * visual_size(o))
     end
 
 end
@@ -63,14 +57,14 @@ end
 #-------------------------------------
 # draw point origin
 #-------------------------------------
-function OpticSim.Vis.draw!(scene::Makie.LScene, o::Origins.Point; transform::Geometry.Transform = Transform(), kwargs...) where {T<:Real}
-        maybe_draw_debug_info(scene, o; transform=transform, kwargs...)
+function OpticSim.Vis.draw!(ax::Makie.AbstractAxis, o::Origins.Point; transform::Geometry.Transform = Transform(), kwargs...) where {T<:Real}
+        maybe_draw_debug_info(ax, o; transform=transform, kwargs...)
 end
 
 #-------------------------------------
 # draw RectGrid and RectUniform origins
 #-------------------------------------
-function OpticSim.Vis.draw!(scene::Makie.LScene, o::Union{Origins.RectGrid, Origins.RectUniform}; transform::Geometry.Transform = Transform(), kwargs...) where {T<:Real}
+function OpticSim.Vis.draw!(ax::Makie.AbstractAxis, o::Union{Origins.RectGrid, Origins.RectUniform}; transform::Geometry.Transform = Transform(), kwargs...) where {T<:Real}
     dir = forward(transform)
     uv = SVector{3}(right(transform))
     vv = SVector{3}(up(transform))
@@ -81,16 +75,16 @@ function OpticSim.Vis.draw!(scene::Makie.LScene, o::Union{Origins.RectGrid, Orig
     plane = OpticSim.Plane(dir, pos)
     rect = OpticSim.Rectangle(plane, o.width / 2, o.height / 2, uv, vv)
     
-    OpticSim.Vis.draw!(scene, rect;  kwargs...)
+    OpticSim.Vis.draw!(ax, rect;  kwargs...)
 
-    maybe_draw_debug_info(scene, o; transform=transform, kwargs...)
+    maybe_draw_debug_info(ax, o; transform=transform, kwargs...)
 end
 
 
 #-------------------------------------
 # draw hexapolar origin
 #-------------------------------------
-function OpticSim.Vis.draw!(scene::Makie.LScene, o::Origins.Hexapolar; transform::Geometry.Transform = Transform(), kwargs...) where {T<:Real}
+function OpticSim.Vis.draw!(ax::Makie.AbstractAxis, o::Origins.Hexapolar; transform::Geometry.Transform = Transform(), kwargs...) where {T<:Real}
     dir = forward(transform)
     uv = SVector{3}(right(transform))
     vv = SVector{3}(up(transform))
@@ -99,17 +93,17 @@ function OpticSim.Vis.draw!(scene::Makie.LScene, o::Origins.Hexapolar; transform
     plane = OpticSim.Plane(dir, pos)
     ellipse = OpticSim.Ellipse(plane, o.halfsizeu, o.halfsizev, uv, vv)
     
-    OpticSim.Vis.draw!(scene, ellipse;  kwargs...)
+    OpticSim.Vis.draw!(ax, ellipse;  kwargs...)
 
-    maybe_draw_debug_info(scene, o; transform=transform, kwargs...)
+    maybe_draw_debug_info(ax, o; transform=transform, kwargs...)
 end
 
 #-------------------------------------
 # draw source
 #-------------------------------------
-function OpticSim.Vis.draw!(scene::Makie.LScene, s::S; parent_transform::Geometry.Transform = Transform(), debug::Bool=false, kwargs...) where {T<:Real,S<:Sources.AbstractSource{T}}
+function OpticSim.Vis.draw!(ax::Makie.AbstractAxis, s::S; parent_transform::Geometry.Transform = Transform(), debug::Bool=false, kwargs...) where {T<:Real,S<:Sources.AbstractSource{T}}
    
-    OpticSim.Vis.draw!(scene, Emitters.Sources.origins(s);  transform=parent_transform * Emitters.Sources.transform(s), debug=debug, kwargs...)
+    OpticSim.Vis.draw!(ax, Emitters.Sources.origins(s);  transform=parent_transform * Emitters.Sources.transform(s), debug=debug, kwargs...)
 
     if (debug)
         m = zeros(T, length(s), 7)
@@ -121,21 +115,16 @@ function OpticSim.Vis.draw!(scene::Makie.LScene, s::S; parent_transform::Geometr
         
         m[:, 4:6] .*= m[:, 7] * ARRROW_LENGTH * visual_size(Emitters.Sources.origins(s))  
 
-        # Makie.arrows!(scene, [Makie.Point3f(origin(ray))], [Makie.Point3f(rayscale * direction(ray))]; kwargs..., arrowsize = min(0.05, rayscale * 0.05), arrowcolor = color, linecolor = color, linewidth = 2)
         color = :yellow
         arrow_size = ARRROW_SIZE * visual_size(Emitters.Sources.origins(s))
-        Makie.arrows!(scene, m[:,1], m[:,2], m[:,3], m[:,4], m[:,5], m[:,6]; kwargs...,  arrowcolor=color, linecolor=color, arrowsize=arrow_size, linewidth=arrow_size*0.5)
+        Makie.arrows!(ax, m[:,1], m[:,2], m[:,3], m[:,4], m[:,5], m[:,6]; kwargs...,  arrowcolor=color, linecolor=color, arrowsize=arrow_size, linewidth=arrow_size*0.5)
     end
-
-    # for ray in o
-    #     OpticSim.Vis.draw!(scene, ray)
-    # end
 end
 
 #-------------------------------------
 # draw optical rays
 #-------------------------------------
-function OpticSim.Vis.draw!(scene::Makie.LScene, rays::AbstractVector{OpticSim.OpticalRay{T, 3}};
+function OpticSim.Vis.draw!(ax::Makie.AbstractAxis, rays::AbstractVector{OpticSim.OpticalRay{T, 3}};
     debug::Bool = false,  # make sure debug does not end up in kwargs (Makie would error)
     kwargs...
 ) where {T<:Real}
@@ -147,14 +136,14 @@ function OpticSim.Vis.draw!(scene::Makie.LScene, rays::AbstractVector{OpticSim.O
     end
     
     color = :green
-    Makie.linesegments!(scene, m[:,1], m[:,2], m[:,3]; kwargs...,  color = color, linewidth = 2, )
+    Makie.linesegments!(ax, m[:,1], m[:,2], m[:,3]; kwargs...,  color = color, linewidth = 2, )
 end
 
 #-------------------------------------
 # draw composite source
 #-------------------------------------
-function OpticSim.Vis.draw!(scene::Makie.LScene, s::Sources.CompositeSource{T}; parent_transform::Geometry.Transform = Transform(), kwargs...) where {T<:Real}
+function OpticSim.Vis.draw!(ax::Makie.AbstractAxis, s::Sources.CompositeSource{T}; parent_transform::Geometry.Transform = Transform(), kwargs...) where {T<:Real}
     for source in s.sources
-        OpticSim.Vis.draw!(scene, source; parent_transform=parent_transform*Emitters.Sources.transform(s), kwargs...)
+        OpticSim.Vis.draw!(ax, source; parent_transform=parent_transform*Emitters.Sources.transform(s), kwargs...)
     end
 end

--- a/src/Vis/Visualization.jl
+++ b/src/Vis/Visualization.jl
@@ -58,6 +58,7 @@ end
 # all functions follow the pattern draw(obj) and draw!(ax, obj) where the first case draws the object in a blank Axis and displays it, and
 # the second case draws the object in an existing Axis, draw!(obj) can also be used to draw the object in the current Axis
 
+# Those should be renamed (e.g. `scene()` returns a Figure), or removed?
 global current_main_scene = nothing
 global current_3d_scene = nothing
 global current_mode = nothing           # modes:    nothing, :default  -> Original Vis behavior    

--- a/src/Vis/Visualization.jl
+++ b/src/Vis/Visualization.jl
@@ -178,12 +178,7 @@ end
 Save the current Makie scene to an image file.
 """
 function save(path::String)
-    # save closes the window so just display it again as a work-around
-    # for some reason the size isn't maintained automatically so we just reset it manually
-    size = Makie.size(current_main_scene)
-    Makie.save(path, current_3d_scene.scene)
-    Makie.resize!(current_main_scene, size)
-    display(current_main_scene)
+    Makie.save(path, current_main_scene; update = false)
 end
 function save(::Nothing) end
 

--- a/src/Vis/Visualization.jl
+++ b/src/Vis/Visualization.jl
@@ -110,20 +110,17 @@ function scene(resolution = (1000, 1000))
     savebutton = Makie.Button(buttons_layout[1, 4], label = "Screenshot", buttoncolor = RGB(0.8, 0.8, 0.8), height = 40, width = 160)
 
     Makie.on(threedbutton.clicks) do nclicks
-        cam3d = Makie.cameracontrols(ax)
-        Makie.update_cam!(ax.scene, cam3d, +π / 4, π / 4)
+        update_camera_orientation!(ax, π / 4, π / 4)
         yield()
     end
 
     Makie.on(twodybutton.clicks) do nclicks
-        cam3d = Makie.cameracontrols(ax)
-        Makie.update_cam!(ax.scene, cam3d, π / 2, 0.0)
+        update_camera_orientation!(ax, π / 2, 0.0)
         yield()
     end
 
     Makie.on(twodxbutton.clicks) do nclicks
-        cam3d = Makie.cameracontrols(ax)
-        Makie.update_cam!(ax.scene, cam3d, 0.0, 0.0)
+        update_camera_orientation!(ax, 0.0, 0.0)
         yield()
     end
 
@@ -133,6 +130,17 @@ function scene(resolution = (1000, 1000))
     end
 
     return fig, ax
+end
+
+
+"""
+    update_camera_orientation(ax::Makie.AbstractAxis, ϕ, θ)
+
+Set the camera position based on two angles 0 ≤ ϕ ≤ 2π and -pi/2 ≤ θ ≤ pi/2.
+"""
+function update_camera_orientation!(ax::Makie.AbstractAxis, ϕ, θ)
+    cam3d = Makie.cameracontrols(ax)
+    Makie.update_cam!(ax.scene, cam3d, ϕ, θ)
 end
 
 

--- a/src/Vis/Visualization.jl
+++ b/src/Vis/Visualization.jl
@@ -59,7 +59,6 @@ end
 # the second case draws the object in an existing Axis, draw!(obj) can also be used to draw the object in the current Axis
 
 global current_main_scene = nothing
-global current_layout_scene = nothing
 global current_3d_scene = nothing
 global current_mode = nothing           # modes:    nothing, :default  -> Original Vis behavior    
                                         #           :pluto             -> support pluto notebooks 
@@ -91,7 +90,6 @@ function scene(resolution = (1000, 1000))
 
     fig = Makie.Figure(size = resolution)
     global current_main_scene = fig
-    global current_layout_scene = fig.layout
 
     ax = Makie.LScene(fig[1, 1];
         scenekw = (; camera = Makie.cam3d_cad!)

--- a/src/Vis/Visualization.jl
+++ b/src/Vis/Visualization.jl
@@ -93,7 +93,9 @@ function scene(resolution = (1000, 1000))
     global current_main_scene = fig
     global current_layout_scene = fig.layout
 
-    ax = Makie.Axis3(fig[1, 1]; aspect = :data)
+    ax = Makie.LScene(fig[1, 1];
+        scenekw = (; camera = Makie.cam3d_cad!)
+    )
     global current_3d_scene = ax
 
     # in these modes we want to skip the creation of the utility buttons as these modes are not interactive
@@ -108,20 +110,20 @@ function scene(resolution = (1000, 1000))
     savebutton = Makie.Button(buttons_layout[1, 4], label = "Screenshot", buttoncolor = RGB(0.8, 0.8, 0.8), height = 40, width = 160)
 
     Makie.on(threedbutton.clicks) do nclicks
-        ax.azimuth[] = -π / 4
-        ax.elevation[] = π / 4
+        cam3d = Makie.cameracontrols(ax)
+        Makie.update_cam!(ax.scene, cam3d, +π / 4, π / 4)
         yield()
     end
 
     Makie.on(twodybutton.clicks) do nclicks
-        ax.azimuth[] = π / 2
-        ax.elevation[] = 0.0
+        cam3d = Makie.cameracontrols(ax)
+        Makie.update_cam!(ax.scene, cam3d, π / 2, 0.0)
         yield()
     end
 
     Makie.on(twodxbutton.clicks) do nclicks
-        ax.azimuth[] = 0.0
-        ax.elevation[] = 0.0
+        cam3d = Makie.cameracontrols(ax)
+        Makie.update_cam!(ax.scene, cam3d, 0.0, 0.0)
         yield()
     end
 

--- a/src/Vis/Visualization.jl
+++ b/src/Vis/Visualization.jl
@@ -273,7 +273,12 @@ Transforms `surf` into a mesh using [`makemesh`](@ref) and draws the result.
 `numdivisions` determines the resolution with which the mesh is triangulated.
 `kwargs` is passed on to the [`TriangleMesh`](@ref) drawing function.
 """
-function draw!(ax::Makie.AbstractAxis, surf::Surface{T}; numdivisions::Int = 30, normals::Bool = false, normalcolor = :blue, kwargs...) where {T<:Real}
+function draw!(ax::Makie.AbstractAxis, surf::Surface{T};
+    numdivisions::Int = 30,
+    normals::Bool = false,
+    normalcolor = :blue,
+    kwargs...
+) where {T<:Real}
     mesh = makemesh(surf, numdivisions)
     if nothing === mesh
         return
@@ -331,7 +336,10 @@ end
 Draw a series of [`TriangleMesh`](@ref) or [`Surface`](@ref) objects, if `colors` is true then each mesh will be colored automatically with a diverse series of colors.
 `kwargs` are is passed on to the drawing function for each element.
 """
-function draw!(ax::Makie.AbstractAxis, meshes::Vararg{S}; colors::Bool = false, kwargs...) where {T<:Real,S<:Union{TriangleMesh{T},Surface{T}}}
+function draw!(ax::Makie.AbstractAxis, meshes::Vararg{S};
+    colors::Bool = false,
+    kwargs...
+) where {T<:Real, S<:Union{TriangleMesh{T}, Surface{T}}}
     for i in 1:length(meshes)
         if colors
             col = indexedcolor2(i)


### PR DESCRIPTION
This PR should fix #19.
`samples/notebooks/EmittersIntro.jl` still works.

Sorry about the LScene => Axis3 => LScene round trip.
`Axis3` does not allow to zoom, unfortunately, as said on [discourse](https://discourse.julialang.org/t/makie-programmatic-control-of-camera/90949/7).
Getting back to `::LScene` rather than `::AbstractAxis` would simplify review,
but would require some work (it can't be a simple revert),
and keeping it an `ax::AbstractAxis` does convey the fact that it is usually more than a basic `Scene`.

Need to think about renaming / removing the global variables (or not).
That might require to break the API,
and so is better left for later, right?
