### PR TITLE
FixDocumentation

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1.11'
       - name: Install dependencies
         run: |
           xvfb-run julia --project=docs/ -e '

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "OpticSim"
 uuid = "24114763-4efb-45e7-af0e-cde916beb153"
 authors = ["Brian Guenter", "Charlie Hewitt", "Ran Gal", "Alfred Wong"]
 repository = "https://github.com/microsoft/OpticSim.jl"
-version = "0.7.1"
+version = "0.7.0"
 
 [deps]
 AGFFileReader = "36dd7d7d-c279-4b5c-a024-2ba417cea492"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ OpticSim.jl is a [Julia](https://julialang.org/) package for geometric optics. O
 
 A large variety of surface types are supported, and these can be composed into complex 3D objects through the use of constructive solid geometry (CSG). A substantial catalog of optical materials is provided through the AGFFileReader package.
 
-This package is currently undergoing a significant rewrite. The latest versions of the package do not have full functionality yet.
+### Package status
+This package is currently undergoing a significant rewrite. The latest versions of the package do not have full functionality yet. The core ray tracing works (in the package `OpticSim`) but the glass catalog download, visualization, and repeating structures code has been moved into separate packages: `AGFFileReader`,`OpticSimVisualization`,`OpticSimRepeatingStructures`. The last two packages are not yet full functional.
 ## Contributing
 
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ OpticSim.jl is a [Julia](https://julialang.org/) package for geometric optics. O
 
 A large variety of surface types are supported, and these can be composed into complex 3D objects through the use of constructive solid geometry (CSG). A substantial catalog of optical materials is provided through the AGFFileReader package.
 
-
+This package is currently undergoing a significant rewrite. The latest versions of the package do not have full functionality yet.
 ## Contributing
 
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,75 +13,33 @@ Run this example to check that everything installed properly:
 using OpticSim, AGFFileReader
 SphericalLens(AGFFileReader.Examples_N_BK7, 0.0, 10.0, 10.0, 5.0, 5.0)
 ```
-If you want to use downloaded glass files then you will have to call the function `AGFFileReader.initialize_AGFFileReader()` before you 
-Now download glass files. Open a REPL in the `OpticSim.jl` project directory. At the REPL type
-
+`AGFFileReader` includes these 4 glass types to get you started
 ```julia
-julia> using AGFFileReader
-
-julia> initialize_AGFFileReader()
-12-element Vector{Module}:
- AGFFileReader.NIKON
- AGFFileReader.HOYA
- AGFFileReader.ARTON
- AGFFileReader.BIREFRINGENT
- AGFFileReader.CDGM
- AGFFileReader.HERAEUS
- AGFFileReader.HIKARI
- AGFFileReader.ISUZU
- AGFFileReader.LZOS
- AGFFileReader.MISC
- AGFFileReader.UMICORE
- AGFFileReader.ZEON
-```
-In this case 12 glass files were downloaded. Print the properties of a random glass to test that the files were downloaded correctly:
-```julia
-julia> info(NIKON.BAF3)
-Dispersion formula:                                Schott (1)
-Dispersion formula coefficients:
-     a₀:                                           2.438682      
-     a₁:                                           0.001609961   
-     a₂:                                           0.02688829    
-     a₃:                                           -0.002446579  
-     a₄:                                           0.0003965661  
-     a₅:                                           -1.973046e-5  
-Valid wavelengths:                                 0.4μm to 0.7μm
-Reference temperature:                             20.0°C        
-TCE (÷1e-6):                                       9.1
-Ignore thermal expansion:                          false
-Density (p):                                       3.28g/m³      
-ΔPgF:                                              0.0009        
-RI at sodium D-Line (587nm):                       1.58267       
-Abbe Number:                                       46.476929     
-Cost relative to N_BK7:                            ?
-Status:                                            Obsolete (2)  
-Melt frequency:                                    0
-Exclude substitution:                              false
-Transmission data:
-     Wavelength   Transmission      Thickness
-         0.29μm            0.0         10.0mm
-          0.3μm            0.0         10.0mm
-         0.31μm            0.0         10.0mm
-         0.32μm            0.1         10.0mm
-         0.33μm           0.51         10.0mm
-         0.34μm           0.81         10.0mm
-         0.35μm          0.924         10.0mm
-         0.36μm          0.962         10.0mm
-         0.37μm           0.98         10.0mm
-         0.38μm          0.983         10.0mm
-         0.39μm          0.991         10.0mm
-          0.4μm          0.994         10.0mm
-         0.42μm          0.996         10.0mm
-         0.44μm          0.997         10.0mm
-         0.46μm          0.999         10.0mm
-         0.48μm          0.999         10.0mm
-          0.5μm          0.999         10.0mm
-         0.55μm          0.999         10.0mm
-          0.6μm          0.999         10.0mm
-         0.65μm          0.999         10.0mm
-          0.7μm          0.999         10.0mm
+Examples_N_BK7
+Examples_N_SF14
+Examples_N_SF2
+Examples_N_SK16
 ```
 
-![install test image](assets/test_install.png)
+For serious work you will need more glass types. The `AGFFileReader` package has a function `AGFFileReader.initialize_AGFFileReader()` to make a local database of glass types generated from publicly available glass catalogs on the web. You must call this function **before** you execute your code:
+```julia
+module YourModule
+using OpticSim
+import AGFFileReader
+
+AGFFileReader.initialize_AGFFileReader()
+
+#your code goes here
+
+end #YourModule
+```
+
+The first call to `AGFFileReader.initialize_AGFFileReader()` will search for publicly available glass files on the web and install them into a database locally on your machine. This may take a while. Subsequent calls will detect the local database and skip the download step. See the documentation of `AGFFileReader` for more information.
+
+In previous versions of `OpticSim` the glass catalog download, visualization, and repeating structures code was included in the `OpticSim` package. This caused excessive load times. 
+
+These have been broken out into separate packages: `AGFFileReader`, `OpticSimVisualization`, and `OpticSimRepeatingStructures`. The last two packages are not yet working.
+
+
 
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,14 +7,79 @@ It is designed to allow optical engineers to create optical systems procedurally
 A large variety of surface types are supported, and these can be composed into complex 3D objects through the use of constructive solid geometry (CSG). A complete catalog of optical materials is provided through the complementary AGFFileReader package.
 
 ## Installation
-
 Run this example to check that everything installed properly:
 
 ```@example
-using OpticSim
-Vis.draw(SphericalLens(Examples.Examples_N_BK7, 0.0, 10.0, 10.0, 5.0, 5.0))
-Vis.save("assets/test_install.png") # hide
-nothing # hide
+using OpticSim, AGFFileReader
+SphericalLens(AGFFileReader.Examples_N_BK7, 0.0, 10.0, 10.0, 5.0, 5.0)
+```
+If you want to use downloaded glass files then you will have to call the function `AGFFileReader.initialize_AGFFileReader()` before you 
+Now download glass files. Open a REPL in the `OpticSim.jl` project directory. At the REPL type
+
+```julia
+julia> using AGFFileReader
+
+julia> initialize_AGFFileReader()
+12-element Vector{Module}:
+ AGFFileReader.NIKON
+ AGFFileReader.HOYA
+ AGFFileReader.ARTON
+ AGFFileReader.BIREFRINGENT
+ AGFFileReader.CDGM
+ AGFFileReader.HERAEUS
+ AGFFileReader.HIKARI
+ AGFFileReader.ISUZU
+ AGFFileReader.LZOS
+ AGFFileReader.MISC
+ AGFFileReader.UMICORE
+ AGFFileReader.ZEON
+```
+In this case 12 glass files were downloaded. Print the properties of a random glass to test that the files were downloaded correctly:
+```julia
+julia> info(NIKON.BAF3)
+Dispersion formula:                                Schott (1)
+Dispersion formula coefficients:
+     a₀:                                           2.438682      
+     a₁:                                           0.001609961   
+     a₂:                                           0.02688829    
+     a₃:                                           -0.002446579  
+     a₄:                                           0.0003965661  
+     a₅:                                           -1.973046e-5  
+Valid wavelengths:                                 0.4μm to 0.7μm
+Reference temperature:                             20.0°C        
+TCE (÷1e-6):                                       9.1
+Ignore thermal expansion:                          false
+Density (p):                                       3.28g/m³      
+ΔPgF:                                              0.0009        
+RI at sodium D-Line (587nm):                       1.58267       
+Abbe Number:                                       46.476929     
+Cost relative to N_BK7:                            ?
+Status:                                            Obsolete (2)  
+Melt frequency:                                    0
+Exclude substitution:                              false
+Transmission data:
+     Wavelength   Transmission      Thickness
+         0.29μm            0.0         10.0mm
+          0.3μm            0.0         10.0mm
+         0.31μm            0.0         10.0mm
+         0.32μm            0.1         10.0mm
+         0.33μm           0.51         10.0mm
+         0.34μm           0.81         10.0mm
+         0.35μm          0.924         10.0mm
+         0.36μm          0.962         10.0mm
+         0.37μm           0.98         10.0mm
+         0.38μm          0.983         10.0mm
+         0.39μm          0.991         10.0mm
+          0.4μm          0.994         10.0mm
+         0.42μm          0.996         10.0mm
+         0.44μm          0.997         10.0mm
+         0.46μm          0.999         10.0mm
+         0.48μm          0.999         10.0mm
+          0.5μm          0.999         10.0mm
+         0.55μm          0.999         10.0mm
+          0.6μm          0.999         10.0mm
+         0.65μm          0.999         10.0mm
+          0.7μm          0.999         10.0mm
 ```
 
 ![install test image](assets/test_install.png)

--- a/samples/notebooks/EmittersIntro.jl
+++ b/samples/notebooks/EmittersIntro.jl
@@ -46,7 +46,7 @@ begin
         DataFrame(SurfaceType=["Object", "Standard", "Standard", "Standard", "Stop", "Standard", "Standard", "Image"],
             Radius=[Inf, 26.777, 66.604, -35.571, 35.571, 35.571, -26.777, Inf],
             Thickness=[Inf, 4.0, 2.0, 4.0, 2.0, 4.0, 44.748, missing],
-            Material=[AGFFileReader.Air, OpticSim.Examples.Examples_N_SK16, AGFFileReader.Air, OpticSim.Examples.Examples_N_SF2, AGFFileReader.Air, OpticSim.Examples.Examples_N_SK16, AGFFileReader.Air, missing],
+            Material=[AGFFileReader.Air, AGFFileReader.Examples_N_SK16, AGFFileReader.Air, AGFFileReader.Examples_N_SF2, AGFFileReader.Air, AGFFileReader.Examples_N_SK16, AGFFileReader.Air, missing],
             SemiDiameter=[Inf, 8.580, 7.513, 7.054, 6.033, 7.003, 7.506, 15.0]))
     @show sys
 end

--- a/samples/notebooks/Samples.jl
+++ b/samples/notebooks/Samples.jl
@@ -43,7 +43,7 @@ begin
         DataFrame(SurfaceType=["Object", "Standard", "Standard", "Standard", "Stop", "Standard", "Standard", "Image"],
             Radius=[Inf, 26.777, 66.604, -35.571, 35.571, 35.571, -26.777, Inf],
             Thickness=[Inf, 4.0, 2.0, 4.0, 2.0, 4.0, 44.748, missing],
-            Material=[AGFFileReader.Air, OpticSim.Examples.Examples_N_SK16, AGFFileReader.Air, OpticSim.Examples.Examples_N_SF2, AGFFileReader.Air, OpticSim.Examples.Examples_N_SK16, AGFFileReader.Air, missing],
+            Material=[AGFFileReader.Air, AGFFileReader.Examples_N_SK16, AGFFileReader.Air, AGFFileReader.Examples_N_SF2, AGFFileReader.Air, AGFFileReader.Examples_N_SK16, AGFFileReader.Air, missing],
             SemiDiameter=[Inf, 8.580, 7.513, 7.054, 6.033, 7.003, 7.506, 15.0]))
     @show sys_cooke
 end


### PR DESCRIPTION
documentation still refers to old submodules that have been broken out into separate packages: AGFFileReader, OptSimVisualization, OpticSimRepeatingStructures. 

This PR fixes this.